### PR TITLE
New simulation mode + other minor additions

### DIFF
--- a/colony_ant_simulator.py
+++ b/colony_ant_simulator.py
@@ -99,7 +99,7 @@ class Pheromone:
         """
         self.posx = ant.posx
         self.posy = ant.posy
-        self.life = _CONFIG_['pheromone']['lifeexpectancy'] # Life expectancy of the pheromone which expires after a certain time
+        self.life = _CONFIG_['pheromone']['persistence'] # Life expectancy of the pheromone which expires after a certain time
         self.display = circle(self.posx, self.posy, _CONFIG_['graphics']['pheromone']['radius'], canvas, _CONFIG_['graphics']['pheromone']['colour'])
 
 
@@ -315,8 +315,9 @@ def f_move(canvas, ant_data, food, status_vars):
                 canvas.itemconfig(ant.display, fill=_CONFIG_['graphics']['ant']['notscouting_colour'])
 
                 # the ant puts down its first pheromones when it touches food
-                for i in range(30):
-                    pheromones.append(Pheromone(ant, canvas))
+                _ = [pheromones.append(Pheromone(ant, canvas))
+                     for i in range(_CONFIG_['pheromone']['qty_ph_upon_foodfind'])]
+                    
 
         else:  # If the ant found the food source
             # The position of the nest will influence the movements of the ant
@@ -327,7 +328,7 @@ def f_move(canvas, ant_data, food, status_vars):
             ant.posx += coord[0]
             ant.posy += coord[1]
             canvas.move(ant.display, coord[0], coord[1])
-            # if there is a collision between a nest and an ant, the ant switches to scout mode
+            # Ant at nest: if there is a collision between a nest and an ant, the ant switches to scout mode
             if collide(canvas, ant) == 1:
                 ant.scout_mode = True
                 canvas.itemconfig(ant.display, fill=_CONFIG_['graphics']['ant']['scouting_colour'])

--- a/colony_ant_simulator.py
+++ b/colony_ant_simulator.py
@@ -2,6 +2,8 @@
 
 import ut
 
+import argparse
+
 from copy import copy
 from random import choice, randrange, randint
 from coloraide import Color
@@ -203,10 +205,10 @@ def find_nest(ant, canvas):
     BGn = BG_o[0]
     BDn = BD_o[0]
 
-    HG = len(HG_o) - 2 - nb_ant
-    HD = len(HD_o) - 2 - nb_ant
-    BG = len(BG_o) - 2 - nb_ant
-    BD = len(BD_o) - 2 - nb_ant
+    HG = len(HG_o) - 2 - sim_args.n_ants
+    HD = len(HD_o) - 2 - sim_args.n_ants
+    BG = len(BG_o) - 2 - sim_args.n_ants
+    BD = len(BD_o) - 2 - sim_args.n_ants
 
     new_move_tab = []
     if HGn == 1:
@@ -246,10 +248,10 @@ def pheromones_affinity(ant, canvas):
     HD_o = canvas.find_overlapping(e_w, 0, ant_coords[0], ant_coords[1])
     BG_o = canvas.find_overlapping(0, e_h, ant_coords[0], ant_coords[1])
     BD_o = canvas.find_overlapping(e_w, e_h, ant_coords[0], ant_coords[1])
-    HG = len(HG_o) - (2 + nb_ant)
-    HD = len(HD_o) - (2 + nb_ant)
-    BG = len(BG_o) - (2 + nb_ant)
-    BD = len(BD_o) - (2 + nb_ant)
+    HG = len(HG_o) - (2 + sim_args.n_ants)
+    HD = len(HD_o) - (2 + sim_args.n_ants)
+    BG = len(BG_o) - (2 + sim_args.n_ants)
+    BD = len(BD_o) - (2 + sim_args.n_ants)
     new_move_tab = []
 
     if HG > 1:
@@ -330,9 +332,9 @@ def f_move(canvas, ant_data, food, status_vars):
                 ant.scout_mode = True
                 canvas.itemconfig(ant.display, fill=_CONFIG_['graphics']['ant']['scouting_colour'])
 
-        if nb_ant <= 100:
+        if sim_args.n_ants<= 100:
             canvas.update()
-    if nb_ant > 100:
+    if sim_args.n_ants > 100:
         canvas.update()
     
     # Refresh status bar
@@ -344,11 +346,12 @@ def f_move(canvas, ant_data, food, status_vars):
 
 if __name__ == "__main__":
     try:
-        nb_ant = int(input(
-            "Enter the number of ants you want for the simulation (recommended: 10-100) \n "
-            "or leave the field blank for a random choice: ") or randint(10, 100)
-                     )
-        Environment(nb_ant)
+        parser = argparse.ArgumentParser(description='Simulation of ants colony in python.')
+        parser.add_argument('n_ants', type=int, nargs='?', default=randint(10, 100), 
+                            help='Number of ants (recommended: 10-100)')
+        sim_args = parser.parse_args()
+
+        Environment(sim_args.n_ants)
     except KeyboardInterrupt:
         print("Exiting...")
         exit(0)

--- a/colony_ant_simulator.py
+++ b/colony_ant_simulator.py
@@ -130,7 +130,8 @@ class Environment:
         # Setup status bar
         self.status_vars = [StringVar() for i in range (6)]
         _ = [var.set(f'Ini ({i}) ...') for i, var in enumerate(self.status_vars)]
-        _ = [Label(self.root, textvariable=var).grid(column=i, row=1, sticky='nw') for i, var in enumerate(self.status_vars)]
+        _ = [Label(self.root, textvariable=var).grid(column=i, row=1, sticky='nw') for i, var in enumerate(self.status_vars[:3])]
+        _ = [Label(self.root, textvariable=var).grid(column=i, row=2, sticky='nw') for i, var in enumerate(self.status_vars[3:])]
 
         # Initialization of the nest
         self.nest = Nest(self.environment)
@@ -167,11 +168,11 @@ class Environment:
             number_new_ants = int(self.nest.food_storage // _CONFIG_['ant']['energy_to_create_new_ant'])
             self.ant_data = self.ant_data + [Ant(self.nest, self.environment) for i in range(number_new_ants)]
             self.nest.food_storage -= number_new_ants * _CONFIG_['ant']['energy_to_create_new_ant']
-            print(f'Welcoming {number_new_ants} new ants to the colony.')
+            print(f'[{self.sim_loop}] Welcoming {number_new_ants} new ants to the colony.')
 
         # Check if we have any ant still alive...
         if len(self.ant_data) == 0:
-            print("All ants have died and the colony didn't survive a tragical famine.\nExiting...")
+            print(f"[{self.sim_loop}] All ants have died and the colony didn't survive a tragical famine.\nExiting...")
             exit(0)
         nb_ants_before_famine = len(self.ant_data)
 
@@ -210,7 +211,7 @@ class Environment:
                     # with each collision between an ant and a food source, its life expectancy decreases by 1
                     self.food.life -= 1
                     self.environment.itemconfig(self.food.display, fill=get_food_colour(self.food.life))
-                    ant.energy = 100
+                    ant.energy = _CONFIG_['ant']['ini_energy']
 
                     # If the food source has been consumed, a new food source is replaced
                     if self.food.life < 1:
@@ -249,7 +250,7 @@ class Environment:
         
         nb_ants_died = nb_ants_before_famine - len(self.ant_data)
         if nb_ants_died > 0:
-            print(f'{nb_ants_died} have died of starvation')
+            print(f'[{self.sim_loop}] {nb_ants_died} ants have died of starvation.')
                 
         if len(self.ant_data) > 100:
             self.environment.update()
@@ -259,7 +260,7 @@ class Environment:
             avg_energy = sum([an_ant.energy for an_ant in self.ant_data])/len(self.ant_data)
         else:
             avg_energy = 0
-        self.status_vars[0].set(f'Loop {self.sim_loop}')
+        self.status_vars[0].set(f'Sim loop {self.sim_loop}')
         self.status_vars[1].set(f'Ants: {len(self.ant_data)}')
         self.status_vars[2].set(f'Energy/ant: {avg_energy:.2f}')
         self.status_vars[3].set(f'Food reserve: {self.nest.food_storage:.2f}')

--- a/colony_ant_simulator.py
+++ b/colony_ant_simulator.py
@@ -4,6 +4,7 @@ import ut
 
 from copy import copy
 from random import choice, randrange, randint
+from coloraide import Color
 from tkinter import *
 import tomllib
 
@@ -54,7 +55,7 @@ class Food:
 
         self.posx = randrange(50, 450)
         self.posy = randrange(50, 450)
-        self.display = circle(self.posx, self.posy, randint(10, 25), canvas, from_rgb(self.life))
+        self.display = circle(self.posx, self.posy, randint(10, 25), canvas, get_food_colour(self.life))
 
     def replace(self, canvas):
         """Relocates the food source to another location when its lifespan reaches 0
@@ -156,14 +157,13 @@ def circle(x, y, radius, canvas, color):
     """
     return canvas.create_oval(x - radius, y - radius, x + radius, y + radius, fill=color, outline='')
 
-def from_rgb(food_life):
-    """translates an rgb tuple of int to a tkinter friendly color code
+def get_food_colour(food_life):
+    """translates an food life (100...0) int to a tkinter-friendly color code
     """
-    r = 0
-    g = 2 * food_life
-    b = 2 * food_life
-
-    return f'#{r:02x}{g:02x}{b:02x}'
+    return Color.interpolate([
+        _CONFIG_['graphics']['food']['ini_colour'],
+        _CONFIG_['graphics']['environment']['backgroundcolour']
+    ])((100-food_life)/100).to_string(hex=True)
 
 def dont_out(ant):
     """prevents ants from leaving the environment
@@ -303,12 +303,12 @@ def f_move(canvas, ant_data, food, status_vars):
                 # if there is a collision between a food source and an ant, the scout mode is removed
                 # with each collision between an ant and a food source, its life expectancy decreases by 1
                 food.life -= 1
-                canvas.itemconfig(food.display, fill=from_rgb(food.life))
+                canvas.itemconfig(food.display, fill=get_food_colour(food.life))
 
                 # If the food source has been consumed, a new food source is replaced
                 if food.life < 1:
                     food.replace(canvas)
-                    canvas.itemconfig(food.display, fill=from_rgb(food.life))
+                    canvas.itemconfig(food.display, fill=get_food_colour(food.life))
                 ant.scout_mode = False
                 canvas.itemconfig(ant.display, fill=_CONFIG_['graphics']['ant']['notscouting_colour'])
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 [ant]
-stepsize = 5
+stepsize = 7
 ini_energy = 10
 energy_to_create_new_ant = 50
 
@@ -8,7 +8,8 @@ width = 500
 height = 500
 
 [nest]
-ini_foodqty = 1000
+
+ini_foodqty = 49
 
 [pheromone]
 persistence = 30

--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,8 @@ height = 500
 stepsize = 7
 
 [pheromone]
-lifeexpectancy = 30
+persistence = 30
+qty_ph_upon_foodfind = 30
 
 [graphics]
 ant.radius = 2

--- a/config.toml
+++ b/config.toml
@@ -9,12 +9,13 @@ stepsize = 7
 lifeexpectancy = 30
 
 [graphics]
-environment.backgroundcolour = "#000028"
-nest.radius = 20
-nest.colour = "#F27E1D"
 ant.radius = 2
 ant.scouting_colour = "#AF0220"
 ant.notscouting_colour = "#3BC302"
+environment.backgroundcolour = "#F4F2F0" # Dark mode: "#000028"
+food.ini_colour = "#00C8C8"
+nest.radius = 20
+nest.colour = "#F27E1D"
 pheromone.radius = 0.1
 pheromone.colour = "#050994"
 

--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,12 @@
+[ant]
+stepsize = 7
+
 [environment]
 width = 500
 height = 500
 
-[ant]
-stepsize = 7
+[nest]
+ini_foodqty = 100
 
 [pheromone]
 persistence = 30

--- a/config.toml
+++ b/config.toml
@@ -1,12 +1,14 @@
 [ant]
-stepsize = 7
+stepsize = 5
+ini_energy = 10
+energy_to_create_new_ant = 50
 
 [environment]
 width = 500
 height = 500
 
 [nest]
-ini_foodqty = 100
+ini_foodqty = 1000
 
 [pheromone]
 persistence = 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+coloraide


### PR DESCRIPTION
This PR resolves #13 

List of changes:

- Implemented argparse.
  - Can lauch the app with `python .\colony_ant_simulator.py`
  - Get help with `python .\colony_ant_simulator.py -h`
- Implemented new mode "reality". Previous mode (by default) is called "basic"
  - `python .\colony_ant_simulator.py -m "reality"`
- Implemented ants life-cycle
  - Ants loose energy with each step
  - They fill their energy when they are in contact of a food source, or when they take it from the nest available reserves
  - They die when no energy left
  - If the nest has enough energy, it creates new ants. Note that the energy needed to create a new ant (50) is more than the maximum energy of an ant (10). Representing the additional energy required to make this new being.
- Changed default background to light colour
  - Implemented coloraide to enable fading of food (new package required)
  - Refactored food colouring function with coloraide.interpolate()
- Status bar on 2 levels
- Moved def f_move(self) to be part of class Environment

![image](https://user-images.githubusercontent.com/96680649/218268531-a9576537-aa68-4672-b2f4-bbc81a8e3283.png)
